### PR TITLE
Potential fix for code scanning alert no. 34: Uncontrolled data used in path expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "pino-pretty": "^13.0.0",
     "prettyjson": "^1.2.5",
     "semver": "^7.6.2",
-    "yarn": "^1.22.21"
+    "yarn": "^1.22.21",
+    "sanitize-filename": "^1.6.3"
   },
   "peerDependencies": {
     "artillery": "^2.0.15"


### PR DESCRIPTION
Potential fix for [https://github.com/zotoio/x-fidelity/security/code-scanning/34](https://github.com/zotoio/x-fidelity/security/code-scanning/34)

To fix the problem, we need to ensure that the `archetype` parameter is validated and sanitized before it is used to construct file paths. We can use a library like `sanitize-filename` to remove any special characters from the `archetype` value. Additionally, we should ensure that the constructed paths are within a safe root directory.

1. Install the `sanitize-filename` package.
2. Import the `sanitize-filename` package in the relevant file.
3. Sanitize the `archetype` parameter before using it to construct file paths.
4. Ensure that the constructed paths are within a safe root directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
