### PR TITLE
fix(cli): copy root README to CLI package during release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -51,7 +51,7 @@
       "@semantic-release/exec",
       {
         "verifyReleaseCmd": "echo '🔍 Verifying CLI package.json version: '$(node -p \"require('./package.json').version\")",
-        "prepareCmd": "echo '📝 Current package.json version before npm plugin: '$(node -p \"require('./package.json').version\")",
+        "prepareCmd": "echo '📝 Current package.json version before npm plugin: '$(node -p \"require('./package.json').version\") && echo '📄 Copying root README.md to CLI package...' && cp ../../README.md ./README.md",
         "publishCmd": "echo '📦 Publishing CLI with version: '$(node -p \"require('./package.json').version\")"
       }
     ],

--- a/CONSOLIDATED-TEST-REPORT.md
+++ b/CONSOLIDATED-TEST-REPORT.md
@@ -1,7 +1,7 @@
 # Consolidated Test Report
 
-> **Generated:** 2025-07-29 19:40 GMT+1000  
-> **Duration:** 6.98s  
+> **Generated:** 2025-07-29 20:27 GMT+1000  
+> **Duration:** 67.46s  
 > **Status:** PASSED ✅
 
 ## 📊 Executive Summary
@@ -13,7 +13,7 @@
 | **Test Success Rate** | 100.0% |
 | **Packages Tested** | 6 |
 | **Cache Hit Rate** | 100.0% |
-| **Total Execution Time** | 6.98s |
+| **Total Execution Time** | 67.46s |
 
 ## 🔧 Linting & Code Formatting
 
@@ -37,7 +37,7 @@
 
 | Coverage Type | Percentage |
 |---------------|------------|
-| 📝 **Statements** | 39.4% |
+| 📝 **Statements** | 39.3% |
 | 🌿 **Branches** | 42.2% |
 | 🔧 **Functions** | 34.1% |
 | 📏 **Lines** | 39.3% |
@@ -46,9 +46,9 @@
 
 | Metric | Value |
 |--------|-------|
-| 🎯 **Cache Hits** | 15 tasks |
+| 🎯 **Cache Hits** | 19 tasks |
 | 🔄 **Cache Misses** | 0 tasks |
-| 📊 **Total Tasks** | 15 tasks |
+| 📊 **Total Tasks** | 19 tasks |
 | 📈 **Cache Hit Rate** | 100.0% |
 
 ## 📦 Package Details
@@ -70,7 +70,7 @@
 - **Packages cached:** 0
 
 ### Performance Metrics
-- **Average time per package:** 1.16s
+- **Average time per package:** 11.24s
 - **Cache efficiency:** 100.0% (higher is better)
 
 ### Status Indicators

--- a/packages/x-fidelity-cli/.gitignore
+++ b/packages/x-fidelity-cli/.gitignore
@@ -3,3 +3,6 @@
 # X-Fidelity analysis results
 .xfiResults/
 *.tgz
+
+# Generated during release
+README.md

--- a/packages/x-fidelity-core/package.json
+++ b/packages/x-fidelity-core/package.json
@@ -85,7 +85,6 @@
     "yaml": "^2.7.0"
   },
   "files": [
-    "dist/**/*",
-    "README.md"
+    "dist/**/*"
   ]
 }


### PR DESCRIPTION
- Copy README.md from root during release preparation phase
- Remove README.md from core package files array (private package)
- Add README.md to CLI .gitignore as it's generated during release
- Fixes missing README on npmjs page without maintaining duplicate files

Resolves missing documentation on npm package page while maintaining single source of truth.